### PR TITLE
Update library design

### DIFF
--- a/public/layers/MainMenuLayer.js
+++ b/public/layers/MainMenuLayer.js
@@ -1,13 +1,12 @@
 import {Component, Layer} from "src/gui";
 import {Vector2} from "src/math";
 import {extend} from "src/utils";
-import {gui} from "../main.js";
 import OptionsLayer from "./OptionsLayer.js";
 import {Image, ImageButton} from "../components/index.js";
 
 export default function MainMenuLayer() {
 	/** @override */
-	this.build = () => [
+	this.build = context => [
 		/* new Group({
 			align: Component.alignCenter,
 			margin: new Vector2(0, 0),
@@ -17,45 +16,45 @@ export default function MainMenuLayer() {
 					align: Component.alignLeftTop,
 					margin: new Vector2(0, 0),
 					size: new Vector2(20, 20),
-					image: gui.renderer.textures["gui/widgets.png"],
+					image: context.renderer.textures["gui/widgets.png"],
 					uv: new Vector2(0, 146),
 					onMouseEnter: function() {
 						const newUv = this.getUV();
 						newUv.y = 166;
 						this.setUV(newUv);
 
-						gui.renderQueue.push(this);
-						gui.render();
+						context.renderQueue.push(this);
+						context.render();
 					},
 					onMouseLeave: function() {
 						const newUv = this.getUV();
 						newUv.y = 146;
 						this.setUV(newUv);
 
-						gui.renderQueue.push(this);
-						gui.render();
+						context.renderQueue.push(this);
+						context.render();
 					},
-					onMouseDown: () => gui.push(new OptionsLayer()),
+					onMouseDown: () => context.push(new OptionsLayer()),
 				}),
 				new ImageButton({
 					align: Component.alignRightTop,
 					margin: new Vector2(0, 0),
 					size: new Vector2(20, 20),
-					image: gui.renderer.textures["gui/widgets.png"],
+					image: context.renderer.textures["gui/widgets.png"],
 					uv: new Vector2(0, 186),
 				}),
 				new ImageButton({
 					align: Component.alignLeftBottom,
 					margin: new Vector2(0, 0),
 					size: new Vector2(20, 20),
-					image: gui.renderer.textures["gui/widgets.png"],
+					image: context.renderer.textures["gui/widgets.png"],
 					uv: new Vector2(0, 186),
 				}),
 				new ImageButton({
 					align: Component.alignRightBottom,
 					margin: new Vector2(0, 0),
 					size: new Vector2(20, 20),
-					image: gui.renderer.textures["gui/widgets.png"],
+					image: context.renderer.textures["gui/widgets.png"],
 					uv: new Vector2(0, 186),
 				}),
 			],
@@ -64,7 +63,7 @@ export default function MainMenuLayer() {
 			align: Component.alignLeftTop,
 			margin: new Vector2(0, 0),
 			size: new Vector2(20, 20),
-			image: gui.renderer.textures["gui/widgets.png"],
+			image: context.renderer.textures["gui/widgets.png"],
 			uv: new Vector2(0, 146),
 			onMouseEnter: function() {
 				const subcomponents = this.getSubcomponents();
@@ -72,8 +71,8 @@ export default function MainMenuLayer() {
 
 				this.setSubcomponents(subcomponents);
 
-				gui.renderQueue.push(this);
-				gui.render();
+				context.renderQueue.push(this);
+				context.render();
 			},
 			onMouseLeave: function() {
 				const subcomponents = this.getSubcomponents();
@@ -81,36 +80,36 @@ export default function MainMenuLayer() {
 
 				this.setSubcomponents(subcomponents);
 
-				gui.renderQueue.push(this);
-				gui.render();
+				context.renderQueue.push(this);
+				context.render();
 			},
-			onMouseDown: () => gui.push(new OptionsLayer()),
+			onMouseDown: () => context.push(new OptionsLayer()),
 		}),
 		new ImageButton({
 			align: Component.alignRightTop,
 			margin: new Vector2(0, 0),
 			size: new Vector2(20, 20),
-			image: gui.renderer.textures["gui/widgets.png"],
+			image: context.renderer.textures["gui/widgets.png"],
 			uv: new Vector2(0, 186),
 		}),
 		new ImageButton({
 			align: Component.alignLeftBottom,
 			margin: new Vector2(0, 0),
 			size: new Vector2(20, 20),
-			image: gui.renderer.textures["gui/widgets.png"],
+			image: context.renderer.textures["gui/widgets.png"],
 			uv: new Vector2(0, 186),
 		}),
 		new ImageButton({
 			align: Component.alignRightBottom,
 			margin: new Vector2(0, 0),
 			size: new Vector2(20, 20),
-			image: gui.renderer.textures["gui/widgets.png"],
+			image: context.renderer.textures["gui/widgets.png"],
 			uv: new Vector2(0, 186),
 		}),
 		new Image({
 			align: Component.alignCenter,
 			margin: new Vector2(0, 0),
-			image: gui.renderer.textures["darkgrey"],
+			image: context.renderer.textures["darkgrey"],
 			size: new Vector2(400, 320),
 			uv: new Vector2(0, 0),
 		}),

--- a/public/layers/OptionsLayer.js
+++ b/public/layers/OptionsLayer.js
@@ -1,12 +1,11 @@
 import {Component, Layer} from "src/gui";
 import {Vector2} from "src/math";
 import {extend} from "src/utils";
-import {gui} from "../main.js";
 import {Image, ImageButton} from "../components/index.js";
 
 export default function OptionsLayer() {
 	/** @override */
-	this.build = function() {
+	this.build = function(context) {
 		/** @type {Number} */
 		let counter = 0;
 
@@ -16,14 +15,14 @@ export default function OptionsLayer() {
 			new Image({
 				align: Component.alignCenter,
 				margin: new Vector2(0, 0),
-				image: gui.renderer.textures["overlay"],
+				image: context.renderer.textures["overlay"],
 				size: new Vector2(2000, 2000),
 				uv: new Vector2(0, 0),
 			}),
 			new Image({
 				align: Component.alignCenter,
 				margin: new Vector2(0, 0),
-				image: gui.renderer.textures["grey"],
+				image: context.renderer.textures["grey"],
 				size: new Vector2(300, 180),
 				uv: new Vector2(0, 0),
 			}),
@@ -31,7 +30,7 @@ export default function OptionsLayer() {
 				align: Component.alignCenter,
 				margin: new Vector2(110, -75),
 				size: new Vector2(20, 20),
-				image: gui.renderer.textures["gui/widgets.png"],
+				image: context.renderer.textures["gui/widgets.png"],
 				uv: new Vector2(0, 106),
 				onMouseEnter: function() {
 					const subcomponents = this.getSubcomponents();
@@ -39,8 +38,8 @@ export default function OptionsLayer() {
 
 					this.setSubcomponents(subcomponents);
 
-					gui.renderQueue.push(this);
-					gui.render();
+					context.renderQueue.push(this);
+					context.render();
 				},
 				onMouseLeave: function() {
 					const subcomponents = this.getSubcomponents();
@@ -48,8 +47,8 @@ export default function OptionsLayer() {
 
 					this.setSubcomponents(subcomponents);
 
-					gui.renderQueue.push(this);
-					gui.render();
+					context.renderQueue.push(this);
+					context.render();
 				},
 				onMouseDown: () => console.debug(`Counter = ${++counter}`),
 			}),
@@ -57,7 +56,7 @@ export default function OptionsLayer() {
 				align: Component.alignCenter,
 				margin: new Vector2(134, -75),
 				size: new Vector2(20, 20),
-				image: gui.renderer.textures["gui/widgets.png"],
+				image: context.renderer.textures["gui/widgets.png"],
 				uv: new Vector2(0, 146),
 				onMouseEnter: function() {
 					const subcomponents = this.getSubcomponents();
@@ -65,8 +64,8 @@ export default function OptionsLayer() {
 
 					this.setSubcomponents(subcomponents);
 
-					gui.renderQueue.push(this);
-					gui.render();
+					context.renderQueue.push(this);
+					context.render();
 				},
 				onMouseLeave: function() {
 					const subcomponents = this.getSubcomponents();
@@ -74,10 +73,10 @@ export default function OptionsLayer() {
 
 					this.setSubcomponents(subcomponents);
 
-					gui.renderQueue.push(this);
-					gui.render();
+					context.renderQueue.push(this);
+					context.render();
 				},
-				onMouseDown: () => gui.pop(),
+				onMouseDown: () => context.pop(),
 			}),
 		];
 	};

--- a/public/layers/TestLayer.js
+++ b/public/layers/TestLayer.js
@@ -1,15 +1,18 @@
 import {Component, Layer} from "src/gui";
 import {Vector2} from "src/math";
+import {extend} from "src/utils";
 import {Text} from "../components/index.js";
 
-export default class TestLayer extends Layer {
+export default function TestLayer() {
+	Layer.call(this);
+
 	/** @override */
-	build() {
-		return [
-			new Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", {
-				align: Component.alignCenter,
-				margin: new Vector2(0, 0),
-			}),
-		];
-	}
+	this.build = () => [
+		new Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", {
+			align: Component.alignCenter,
+			margin: new Vector2(0, 0),
+		}),
+	];
 }
+
+extend(TestLayer, Layer);

--- a/public/main.js
+++ b/public/main.js
@@ -1,7 +1,7 @@
 import Instance from "src/instance";
 import {GUI, GUIRenderer} from "src/gui";
-import MainMenuLayer from "./layers/MainMenuLayer.js";
-// import TestLayer from "./layers/TestLayer.js";
+import Layer from "./layers/MainMenuLayer.js";
+// import Layer from "./layers/TestLayer.js";
 
 /** @todo Fix undefined instance on throw */
 
@@ -12,7 +12,10 @@ export let gui;
 let instance;
 
 try {
-	instance = new Instance();
+	instance = new Instance({
+		shaderPath: "assets/shaders/",
+		texturePath: "assets/textures/",
+	});
 
 	gui = new GUI(instance, new GUIRenderer());
 
@@ -24,11 +27,11 @@ try {
 	const textures = await (await fetch("assets/textures/textures.json")).json();
 
 	gui.renderer.createTextureArray(textures.length + 3);
-	await gui.renderer.loadTextures(textures, instance.texturePath);
+	await gui.renderer.loadTextures(textures, instance.getTexturePath());
 	await gui.renderer.loadTestTextures();
 	gui.loadFontSubcomponents(await (await fetch("assets/font/ascii.json")).json());
 
-	gui.push(new MainMenuLayer());
+	gui.push(new Layer());
 
 	instance.startLoop();
 } catch (error) {

--- a/public/main.js
+++ b/public/main.js
@@ -3,20 +3,21 @@ import {GUI, GUIRenderer} from "src/gui";
 import Layer from "./layers/MainMenuLayer.js";
 // import Layer from "./layers/TestLayer.js";
 
-/** @todo Fix undefined instance on throw */
+/**
+ * @todo Fix undefined instance on throw
+ * 
+ * @type {?Instance}
+ */
+let instance;
 
 /** @type {?GUI} */
 export let gui;
-
-/** @type {?Instance} */
-let instance;
 
 try {
 	instance = new Instance({
 		shaderPath: "assets/shaders/",
 		texturePath: "assets/textures/",
 	});
-
 	gui = new GUI(instance, new GUIRenderer());
 
 	instance.build();

--- a/src/Instance.js
+++ b/src/Instance.js
@@ -10,8 +10,11 @@ import {RendererManager} from "./RendererManager.js";
  * 
  * Game instance.
  * This holds information about asset base paths, viewport dimensions and GUI scale.
+ * 
+ * @param {String} shaderPath
+ * @param {String} texturePath
  */
-export default function Instance() {
+export default function Instance({shaderPath, texturePath}) {
 	const DEFAULT_WIDTH = 320;
 	const DEFAULT_HEIGHT = 240;
 	const RESIZE_DELAY = 50;
@@ -46,14 +49,12 @@ export default function Instance() {
 
 	let rendererLength;
 
-	let mouseEnterListeners = [];
-	let mouseEnterListenerCount = 0;
-
-	let mouseLeaveListeners = [];
-	let mouseLeaveListenerCount = 0;
-
-	let mouseDownListeners = [];
-	let mouseDownListenerCount = 0;
+	let mouseEnterListeners = [],
+		mouseEnterListenerCount = 0,
+		mouseLeaveListeners = [],
+		mouseLeaveListenerCount = 0,
+		mouseDownListeners = [],
+		mouseDownListenerCount = 0;
 
 	/**
 	 * @private
@@ -79,19 +80,11 @@ export default function Instance() {
 	 */
 	this.rendererTextures = [];
 
-	/**
-	 * Shader folder path, relative to the root folder.
-	 * 
-	 * @type {?String}
-	 */
-	this.shaderPath = "assets/shaders/";
+	/** @returns {String} */
+	this.getShaderPath = () => shaderPath;
 
-	/**
-	 * Texture folder path, relative to the root folder.
-	 * 
-	 * @type {?String}
-	 */
-	this.texturePath = "assets/textures/";
+	/** @returns {String} */
+	this.getTexturePath = () => texturePath;
 
 	/**
 	 * Cached values of `window.innerWidth` and `window.innerHeight`.
@@ -316,7 +309,7 @@ export default function Instance() {
 		const program = await outputRenderer.loadProgram(
 			"main.vert",
 			"main.frag",
-			this.shaderPath,
+			this.getShaderPath(),
 		);
 
 		outputRenderer.linkProgram(program);

--- a/src/WebGLRenderer.js
+++ b/src/WebGLRenderer.js
@@ -3,6 +3,9 @@ import {Vector2} from "./math/index.js";
 import {Program} from "./Program.js";
 import Texture from "./Texture.js";
 
+/** @type {Vector2} */
+const MAX_TEXTURE_SIZE = new Vector2(256, 256);
+
 /**
  * @todo Convert to function constructor
  * 
@@ -136,11 +139,12 @@ export default class WebGLRenderer {
 	 */
 	createTextureArray(length) {
 		const {gl} = this;
+		const generateMipmaps = this.#generateMipmaps;
 
 		gl.bindTexture(gl.TEXTURE_2D_ARRAY, gl.createTexture());
-		gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 8, gl.RGBA8, 256, 256, length);
+		gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 8, gl.RGBA8, MAX_TEXTURE_SIZE.x, MAX_TEXTURE_SIZE.y, length);
 		gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-		this.#generateMipmaps ?
+		generateMipmaps ?
 			gl.generateMipmap(gl.TEXTURE_2D_ARRAY) :
 			gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 	}

--- a/src/gui/GUI.js
+++ b/src/gui/GUI.js
@@ -235,7 +235,7 @@ export function GUI(instance, renderer) {
 		this.removeListeners(this.tree);
 
 		this.lastInsertionIndices.push(this.tree.length);
-		this.addChildrenToRenderQueue(layer.build(), {
+		this.addChildrenToRenderQueue(layer.build(this), {
 			addListeners: true,
 			addToTree: true,
 		});

--- a/src/gui/GUI.js
+++ b/src/gui/GUI.js
@@ -46,7 +46,8 @@ export function GUI(instance, renderer) {
 	this.fontSubcomponents = {};
 
 	this.init = async function() {
-		const {shaderPath, currentScale} = this.instance;
+		const {currentScale} = this.instance;
+		const shaderPath = this.instance.getShaderPath();
 		const viewport = this.instance.getViewport();
 		const projectionMatrix = this.camera.projectionMatrix = Matrix3
 			.projection(viewport)


### PR DESCRIPTION
- Removed `assets/font/.gitkeep`.
- The shader and texture paths can be set when constructing an `Instance`. Getters have been set to access them outside of the class.
- The `GUI` is now available through the `context` argument of `Layer.build`. Components do not have currently access to it though.
- The max texture size of the `WebGLRenderer` texture array is defined in the `MAX_TEXTURE_SIZE` constant.