### PR TITLE
Refactoring and small optimizations

### DIFF
--- a/assets/shaders/composite.vert
+++ b/assets/shaders/composite.vert
@@ -1,12 +1,11 @@
 #version 300 es
 
 layout(location = 0) in vec2 a_vertex;
-layout(location = 1) in vec2 a_uv;
 
 out vec2 v_uv;
 
 void main() {
 	gl_Position = vec4(a_vertex, 0, 1);
 
-	v_uv = a_uv;
+	v_uv = a_vertex * .5 + .5;
 }

--- a/assets/shaders/subcomponent.frag
+++ b/assets/shaders/subcomponent.frag
@@ -1,7 +1,5 @@
 #version 300 es
 
-#define NORMALIZE_HEX 1.0 / 255.0
-
 precision mediump float;
 precision mediump sampler2DArray;
 
@@ -15,7 +13,6 @@ out vec4 FragColor;
 
 void main() {
 	vec4 texture = texture(u_sampler, vec3(v_uv, v_texture_index));
-	vec3 color = mix(texture.rgb, v_color_mask.rgb * NORMALIZE_HEX, v_color_mask.a);
 
-	FragColor = vec4(color, texture.a);
+	FragColor = texture * v_color_mask;
 }

--- a/public/InstanceRenderer.js
+++ b/public/InstanceRenderer.js
@@ -40,20 +40,13 @@ export function InstanceRenderer() {
 		const textures = this.getTextures();
 
 		attributes.vertex = 0;
-		attributes.uv = 1;
 
 		buffers.vertex = gl.createBuffer();
-		buffers.uv = gl.createBuffer();
 
 		gl.enableVertexAttribArray(attributes.vertex);
 		gl.bindBuffer(gl.ARRAY_BUFFER, buffers.vertex);
 		gl.vertexAttribPointer(attributes.vertex, 2, gl.FLOAT, false, 0, 0);
 		gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 1, -1, 1, -1, -1, 1, -1]), gl.STATIC_DRAW);
-
-		gl.enableVertexAttribArray(attributes.uv);
-		gl.bindBuffer(gl.ARRAY_BUFFER, buffers.uv);
-		gl.vertexAttribPointer(attributes.uv, 2, gl.FLOAT, false, 0, 0);
-		gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 1, 0, 1, 0, 0, 1, 0]), gl.STATIC_DRAW);
 
 		for (let i = 0; i < compositeCount; i++) {
 			gl.bindTexture(gl.TEXTURE_2D, textures[i] = gl.createTexture());

--- a/public/components/Text.js
+++ b/public/components/Text.js
@@ -32,7 +32,7 @@ export function Text(text, {font, color}) {
 		subcomponent = (fontCharacters[symbol] ?? fontCharacters[""]).clone();
 		subcomponent.setOffset(new Vector2(width, 0));
 
-		if (color) subcomponent.setColorMask(new Vector4(color[0], color[1], color[2], 1));
+		if (color) subcomponent.setColorMask(new Vector4(color[0], color[1], color[2], 255));
 
 		subcomponents.push(subcomponent);
 

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,6 @@
 import {Font} from "src";
 import {GUIComposite, GUIRenderer} from "src/gui";
+import {Texture} from "src/wrappers";
 import {Instance} from "./Instance.js";
 import {InstanceRenderer} from "./InstanceRenderer.js";
 import {MainMenuLayer} from "./layers/MainMenuLayer.js";
@@ -62,7 +63,7 @@ try {
 
 		renderer.createTextureArray(textures.length + 3);
 		await renderer.loadTextures(textures, instance.getParameter("texture_path"));
-		await renderer.loadTestTextures();
+		await loadTestTextures(renderer);
 	}
 
 	document.body.appendChild(instance.getRenderer().getCanvas());
@@ -82,4 +83,35 @@ try {
 	instance.dispose();
 
 	if ("node" in error) document.body.appendChild(error.node);
+}
+
+async function loadTestTextures(renderer) {
+	const gl = renderer.getContext();
+	const textures = renderer.getUserTextures();
+	const textureLength = Object.keys(textures).length;
+	const dimension = 256;
+	const imageReplacement = {
+		width: dimension,
+		height: dimension,
+	};
+	const canvas = new OffscreenCanvas(dimension, dimension);
+	const ctx = canvas.getContext("2d");
+	const colors = {
+		darkgrey: "#2b2b2b",
+		grey: "#6f6f6f",
+		overlay: "#000a",
+	};
+	const colorKeys = Object.keys(colors);
+
+	for (let i = 0, l = colorKeys.length, color; i < l; i++) {
+		color = colors[colorKeys[i]];
+
+		ctx.clearRect(0, 0, dimension, dimension);
+		ctx.fillStyle = color;
+		ctx.fillRect(0, 0, dimension, dimension);
+
+		gl.texSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, textureLength + i, dimension, dimension, 1, gl.RGBA, gl.UNSIGNED_BYTE, canvas);
+
+		textures[colorKeys[i]] = new Texture(imageReplacement, textureLength + i);
+	}
 }


### PR DESCRIPTION
- Remove UV buffer, since UV coordinates can be accessed with the current vertex position.
- Remove `Renderer.loadTestTextures` to make it dependant of the project
- Add `Matrix4.perspective` and `Matrix4.lookAt`
- Update the color mask to be an `Uint8Array` normalized automatically by WebGL